### PR TITLE
Add support to pass a rev to iter_commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ optional arguments:
   --entropy DO_ENTROPY  Enable entropy checks
   --since_commit SINCE_COMMIT
                         Only scan from a given commit hash
+  --rev_range FROM...TO       
+                        Only checkout this range of commit hashes
   --branch BRANCH       Scans only the selected branch
   --max_depth MAX_DEPTH
                         The max commit depth to go back when searching for


### PR DESCRIPTION
We have some huge repositories and running trufflehog takes a significant amount of time

GitPython `iter_commits` allows the `rev=A...B` option to be passed in: https://github.com/gitpython-developers/GitPython/blob/4a1339a3d6751b2e7c125aa3195bdc872d45a887/git/repo/base.py#L519:L520

This means it will only look for a specific range of commits when cloning and therefore it should be possible to break up the jobs and make them run in a more repeatable manner.